### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-vultr/config.go
+++ b/cmd/baton-vultr/config.go
@@ -15,6 +15,7 @@ var (
 	baseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Vultr API URL (for testing)"),
+		field.WithHidden(true),
 	)
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or

--- a/cmd/baton-vultr/config.go
+++ b/cmd/baton-vultr/config.go
@@ -12,11 +12,16 @@ var (
 		field.WithIsSecret(true),
 		field.WithRequired(true),
 	)
+	baseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Vultr API URL (for testing)"),
+	)
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or
 	// required.
 	ConfigurationFields = []field.SchemaField{
 		bearerTokenField,
+		baseURLField,
 	}
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/cmd/baton-vultr/config.go
+++ b/cmd/baton-vultr/config.go
@@ -16,6 +16,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Vultr API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or

--- a/cmd/baton-vultr/main.go
+++ b/cmd/baton-vultr/main.go
@@ -50,8 +50,9 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	}
 
 	vultrBearerToken := v.GetString(bearerTokenField.FieldName)
+	baseURL := v.GetString(baseURLField.FieldName)
 
-	connectorBuilder, err := connector.New(ctx, vultrBearerToken)
+	connectorBuilder, err := connector.New(ctx, vultrBearerToken, baseURL)
 	if err != nil {
 		l.Error("error creating newConnector", zap.Error(err))
 		return nil, err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	baseUrl             = "https://api.vultr.com/v2"
+	DefaultBaseURL      = "https://api.vultr.com/v2"
 	getUsers            = "/users"
 	getUserByID         = "/users/%s"
 	getAccountPrincipal = "/account"
@@ -23,9 +23,10 @@ const (
 type VultrClient struct {
 	wrapper     *uhttp.BaseHttpClient
 	TokenSource oauth2.TokenSource
+	baseURL     string
 }
 
-func New(ctx context.Context, bearerToken string) (*VultrClient, error) {
+func New(ctx context.Context, bearerToken string, baseURL string) (*VultrClient, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
@@ -34,22 +35,30 @@ func New(ctx context.Context, bearerToken string) (*VultrClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base HTTP client: %w", err)
 	}
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
 	client := VultrClient{
 		wrapper:     cli,
 		TokenSource: getTokenSource(ctx, bearerToken),
+		baseURL:     baseURL,
 	}
 	return &client, nil
 }
 
-func NewClient(bearerToken string, httpClient ...*uhttp.BaseHttpClient) (*VultrClient, error) {
+func NewClient(bearerToken string, baseURL string, httpClient ...*uhttp.BaseHttpClient) (*VultrClient, error) {
 	tokenSource := getTokenSource(context.Background(), bearerToken)
 	var wrapper = &uhttp.BaseHttpClient{}
 	if len(httpClient) > 0 {
 		wrapper = httpClient[0]
 	}
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
 	return &VultrClient{
 		wrapper:     wrapper,
 		TokenSource: tokenSource,
+		baseURL:     baseURL,
 	}, nil
 }
 
@@ -58,7 +67,7 @@ func (c *VultrClient) ListUsers(ctx context.Context, options PageOptions) ([]Use
 	var res UserResponse
 	var annotation annotations.Annotations
 
-	queryUrl, err := url.JoinPath(baseUrl, getUsers)
+	queryUrl, err := url.JoinPath(c.baseURL, getUsers)
 	if err != nil {
 		l.Error(fmt.Sprintf("Error creating UserResponse URL: %s", err))
 		return nil, "", nil, err
@@ -78,7 +87,7 @@ func (c *VultrClient) ListAccountACLs(ctx context.Context) ([]string, annotation
 	var res AccountResponse
 	var annotation annotations.Annotations
 
-	queryUrl, err := url.JoinPath(baseUrl, getAccountPrincipal)
+	queryUrl, err := url.JoinPath(c.baseURL, getAccountPrincipal)
 	if err != nil {
 		l.Error(fmt.Sprintf("Error creating Account URL: %s", err))
 		return nil, nil, err
@@ -99,7 +108,7 @@ func (c *VultrClient) GetUserByID(ctx context.Context, userID string) (User, ann
 	var user User
 	var annotation annotations.Annotations
 
-	queryUrl, err := url.JoinPath(baseUrl, fmt.Sprintf(getUserByID, userID))
+	queryUrl, err := url.JoinPath(c.baseURL, fmt.Sprintf(getUserByID, userID))
 	if err != nil {
 		l.Error(fmt.Sprintf("Error creating URL: %s", err))
 		return user, nil, err

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -45,10 +45,10 @@ func (d *Connector) Validate(_ context.Context) (annotations.Annotations, error)
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, vultrBearerToken string) (*Connector, error) {
+func New(ctx context.Context, vultrBearerToken string, baseURL string) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
 
-	vultrClient, err := client.New(ctx, vultrBearerToken)
+	vultrClient, err := client.New(ctx, vultrBearerToken, baseURL)
 	if err != nil {
 		l.Error("error creating Vultr client", zap.Error(err))
 		return nil, err

--- a/pkg/connector/integration_test.go
+++ b/pkg/connector/integration_test.go
@@ -26,7 +26,7 @@ func initClient(t *testing.T) *client.VultrClient {
 		t.Skip(message)
 	}
 
-	c, err := client.New(ctx, apiToken)
+	c, err := client.New(ctx, apiToken, "")
 
 	if err != nil {
 		t.Errorf("ERROR: Failed to create client: %v", err)

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -100,7 +100,7 @@ func TestVultrClient_GetUsers_RequestDetails(t *testing.T) {
 	httpClient := &http.Client{Transport: mockTransport}
 	baseHttpClient := uhttp.NewBaseHttpClient(httpClient)
 
-	testClient, err := client.NewClient("access-token-hash", baseHttpClient)
+	testClient, err := client.NewClient("access-token-hash", "", baseHttpClient)
 	if err != nil {
 		t.Fatalf("Error creating client: %v", err)
 	}

--- a/test/helper.go
+++ b/test/helper.go
@@ -105,7 +105,7 @@ func NewTestClient(response *http.Response, err error) *client.VultrClient {
 
 	bearerToken := ""
 
-	newClientT, _ := client.NewClient(bearerToken, baseHttpClient)
+	newClientT, _ := client.NewClient(bearerToken, "", baseHttpClient)
 
 	return newClientT
 }


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-vultr/config.go,cmd/baton-vultr/main.go,pkg/client/client.go,pkg/connector/connector.go,pkg/connector/integration_test.go,pkg/connector/users_test.go,test/helper.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-vultr --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable base URL when initializing the client with automatic default handling when not specified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->