### PR TITLE
fix: mark bearer-token as isSecret in config_schema

### DIFF
--- a/cmd/baton-vultr/config.go
+++ b/cmd/baton-vultr/config.go
@@ -9,6 +9,7 @@ var (
 	bearerTokenField = field.StringField(
 		"bearer-token",
 		field.WithDescription("Bearer Token for authentication"),
+		field.WithIsSecret(true),
 		field.WithRequired(true),
 	)
 	// ConfigurationFields defines the external configuration required for the


### PR DESCRIPTION
## Summary
Marks the credential field(s) **bearer-token** as `isSecret: true` so the value is treated as a secret — masked in the UI and logs and stored securely rather than in plaintext.

Found by the connector config secret-ness audit (phase 16).

`config_schema.json` is generated at build time from `cmd/baton-vultr/config.go` and is not committed to this repo, so `field.WithIsSecret(true)` is the authoritative fix.

> BREAKING: adding `isSecret: true` to these fields changes how existing
> configurations are stored. Customers with existing connector configurations
> will need to re-enter credentials after this change is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)